### PR TITLE
Add outline for OFI programmer's guide

### DIFF
--- a/OFIGuide.md
+++ b/OFIGuide.md
@@ -1,0 +1,105 @@
+---
+layout: page
+title: High Performance Network Programming with OFI
+tagline: Libfabric Programmer's Guide
+---
+{% include JB/setup %}
+
+
+Review of Sockets Communication
+	Connected (TCP) communication
+	Connectionless (UDP) communication
+	Advantages
+	Disadvantages
+High-Performance Networking
+	Avoiding memory copies
+		Network buffers
+		Resource management
+	Asynchronous operations
+		Interrupts and signals
+		Event queues
+	Direct hardware access
+		Kernel bypass
+		Direct data placement
+Designing Interfaces for Performance
+	Call setup costs
+	Branches and loops
+	Command formatting
+	Memory footprint
+		Addressing
+		Communication resources
+		Network Buffering
+			Shared Rx queues
+			Multi-receive buffers
+	Optimal hardware allocation
+		Shared queues
+		Multiple queues
+	Progress model considerations
+	Multi-threading synchronization
+	Ordering
+		Message
+		Completion
+		Data
+OFI Architecture
+	Framework versus Provider
+	Control services
+	Communication services
+	Completion services
+	Data transfer services
+	Memory registration
+Object Model
+Communication Model
+	Connected communications
+	Connectionless communications
+Data Transfers
+	Endpoints
+		Shared Contexts
+			Rx
+			Tx
+		Scalable Endpoints
+	Message transfers
+	Tagged messages
+	RMA
+	Atomic operations
+Fabric Interfaces
+	fi_info / fi_getinfo
+		Capabilities
+		Mode bits
+		Addressing
+	Fabric
+		Attributes
+		Accessing
+	Domains
+		Attributes
+		Opening
+		Memory registration
+	Endpoints
+		Active
+			Enabling
+		Passive
+		Scalable
+		Resource Bindings
+		EP Attributes
+		Rx Attributes
+		Tx Attributes
+	Completions
+		CQs
+			Attributes
+			Reading completions
+			Retrieving errors
+		Counters
+			Checking value
+			Error reporting
+	Address Vectors
+		Types
+		Address formats
+		Insertion methods
+		Sharing with other processes
+	Wait and Poll Sets
+		Blocking on events
+			TryWait
+			Wait
+		Efficiently checking multiple queues
+Putting It All Together
+	MSG EP pingpong
+	RDM EP pingpong

--- a/OFIGuide.md
+++ b/OFIGuide.md
@@ -14,96 +14,107 @@ tagline: Libfabric Programmer's Guide
 ## Disadvantages
 
 # High-Performance Networking
-## Avoiding memory copies
-### Network buffers
-### Resource management
-## Asynchronous operations
-### Interrupts and signals
-### Event queues
-## Direct hardware access
-### Kernel bypass
-### Direct data placement
+## Avoiding Memory Copies
+### Network Buffers
+### Resource Management
+## Asynchronous Operations
+### Interrupts and Signals
+### Event Queues
+## Direct Hardware Access
+### Kernel Bypass
+### Direct Data Placement
 
 # Designing Interfaces for Performance
-## Call setup costs
-## Branches and loops
-## Command formatting
-## Memory footprint
+## Call Setup Costs
+## Branches and Loops
+## Command Formatting
+## Memory Footprint
 ### Addressing
-### Communication resources
+### Communication Resources
 ### Network Buffering
-#### Shared Rx queues
-#### Multi-receive buffers
-## Optimal hardware allocation
-### Shared queues
-### Multiple queues
-## Progress model considerations
-## Multi-threading synchronization
+#### Shared Receive Queues
+#### Multi-Receive Buffers
+## Optimal Hardware Allocation
+### Sharing Command Queues
+### Multiple Queues
+## Progress Model Considerations
+## Multi-Threading Synchronization
 ## Ordering
-### Message
-### Completion
+### Messages
+### Completions
 ### Data
 
 # OFI Architecture
-# Framework versus Provider
-# Control services
+## Framework versus Provider
+## Control services
 ## Communication services
 ## Completion services
 ## Data transfer services
 ## Memory registration
+
 # Object Model
+
 # Communication Model
-## Connected communications
-## Connectionless communications
+## Connected Communications
+## Connectionless Communications
+
 # Data Transfers
 ## Endpoints
 ### Shared Contexts
-#### Rx
-#### Tx
+#### Receive Contexts
+#### Transmit Contexts
 ### Scalable Endpoints
 ## Message transfers
 ## Tagged messages
 ## RMA
 ## Atomic operations
+
 # Fabric Interfaces
-## fi_info / fi_getinfo
+## Using fi_getinfo
 ### Capabilities
-### Mode bits
+### Mode Bits
 ### Addressing
-## Fabric
+
+# Fabric
+## Attributes
+## Accessing
+
+# Domains
+## Attributes
+## Opening
+## Memory Registration
+
+# Endpoints
+## Active
+### Enabling
+## Passive
+## Scalable
+## Resource Bindings
+## EP Attributes
+## Rx Attributes
+## Tx Attributes
+
+# Completions
+## CQs
 ### Attributes
-### Accessing
-## Domains
-### Attributes
-### Opening
-### Memory registration
-## Endpoints
-### Active
-#### Enabling
-### Passive
-### Scalable
-### Resource Bindings
-### EP Attributes
-### Rx Attributes
-### Tx Attributes
-## Completions
-### CQs
-#### Attributes
-#### Reading completions
-#### Retrieving errors
-### Counters
-#### Checking value
-#### Error reporting
-## Address Vectors
-### Types
-### Address formats
-### Insertion methods
-### Sharing with other processes
-## Wait and Poll Sets
-### Blocking on events
-#### TryWait
-#### Wait
-### Efficiently checking multiple queues
+### Reading Completions
+### Retrieving Errors
+## Counters
+### Checking Value
+### Error Reporting
+
+# Address Vectors
+## Types
+## Address Formats
+## Insertion Methods
+## Sharing Addressing Data with other Processes
+
+# Wait and Poll Sets
+## Blocking on events
+### TryWait
+### Wait
+## Efficiently Checking Multiple Queues
+
 # Putting It All Together
 ## MSG EP pingpong
 ## RDM EP pingpong

--- a/OFIGuide.md
+++ b/OFIGuide.md
@@ -7,6 +7,15 @@ tagline: Libfabric Programmer's Guide
 
 
 # Introduction
+
+OpenFabrics Interfaces, or OFI, is a framework focused on exporting fabric communication services to applications.  OFI is specifically designed to meet the performance and scalability requirements of high-performance computing (HPC) applications, such as MPI, SHMEM, PGAS, DBMS, and enterprise applications, running in a tightly coupled network environment.  The key components are OFI are: application interfaces, provider libraries, kernel services, daemons, and test applications.
+
+Libfabric is a core component of OFI. It is the library that defines and exports the user-space API of OFI, and is typically the only software that applications deal with directly. Libfabric is agnostic to the underlying networking protocols, as well as the implementation of the networking devices. 
+
+The goal of OFI, and libfabric specifically, is to define interfaces that enable a tight semantic map between applications and underlying fabric services. Specifically, libfabric software interfaces have been co-designed with fabric hardware providers and application developers, with a focus on the needs of HPC users.
+
+This guide describes the libfabric architecture and interfaces.  It provides insight into the motivation for its design, and aims to instruct developers on how the features of libfabric may best be employed.
+
 # Review of Sockets Communication
 ## Connected (TCP) Communication
 ## Connectionless (UDP) Communication

--- a/OFIGuide.md
+++ b/OFIGuide.md
@@ -28,7 +28,7 @@ tagline: Libfabric Programmer's Guide
 ## Call setup costs
 ## Branches and loops
 ## Command formatting
-##  Memory footprint
+## Memory footprint
 ### Addressing
 ### Communication resources
 ### Network Buffering

--- a/OFIGuide.md
+++ b/OFIGuide.md
@@ -6,74 +6,89 @@ tagline: Libfabric Programmer's Guide
 {% include JB/setup %}
 
 
-Review of Sockets Communication
-	Connected (TCP) communication
-	Connectionless (UDP) communication
-	Advantages
-	Disadvantages
-High-Performance Networking
-	Avoiding memory copies
-		Network buffers
-		Resource management
-	Asynchronous operations
+
+# Introduction
+
+
+OpenFabrics Interfaces, or OFI, is a framework focused on exporting fabric communication services to applications.  OFI is specifically designed to meet the performance and scalability requirements of high-performance computing (HPC) applications, such as MPI, SHMEM, PGAS, DBMS, and enterprise applications, running in a tightly coupled network environment.  The key components are OFI are: application interfaces, provider libraries, kernel services, daemons, and test applications.
+
+Libfabric is a core component of OFI.  It is the library that defines and exports the user-space API of OFI, and is typically the only software that applications deal with directly.  Libfabric is supported on commonly available Linux based distributions.  Libfabric is agnostic to the underlying networking protocols, as well as the implementation of the networking devices.
+
+Libfabric is architected to support process direct I/O.  Process direct I/O, historically referred to as RDMA, allows an application to access network resources without operating system interventions.  Data transfers can occur between networking hardware and application memory with minimal software overhead.  Although libfabric supports process direct I/O, it does not mandate any implementation or require operating system bypass.
+
+
+
+# Review of Sockets Communication
+## Connected (TCP) communication
+## Connectionless (UDP) communication
+## Advantages
+## Disadvantages
+# High-Performance Networking
+## Avoiding memory copies
+### Network buffers
+### Resource management
+## Asynchronous operations
 		Interrupts and signals
 		Event queues
-	Direct hardware access
+## Direct hardware access
 		Kernel bypass
 		Direct data placement
-Designing Interfaces for Performance
-	Call setup costs
-	Branches and loops
-	Command formatting
-	Memory footprint
+# Designing Interfaces for Performance
+## Call setup costs
+## Branches and loops
+## Command formatting
+##  Memory footprint
 		Addressing
 		Communication resources
 		Network Buffering
 			Shared Rx queues
 			Multi-receive buffers
-	Optimal hardware allocation
+## Optimal hardware allocation
 		Shared queues
 		Multiple queues
-	Progress model considerations
-	Multi-threading synchronization
-	Ordering
+## Progress model considerations
+## Multi-threading synchronization
+## Ordering
 		Message
 		Completion
 		Data
-OFI Architecture
-	Framework versus Provider
-	Control services
-	Communication services
-	Completion services
-	Data transfer services
-	Memory registration
-Object Model
-Communication Model
-	Connected communications
-	Connectionless communications
-Data Transfers
-	Endpoints
+# OFI Architecture
+
+# Framework versus Provider
+OFI is divided into two separate components.  The main component is the OFI framework, which defines the interfaces that applications use.  The OFI frameworks provides some generic services; however, the bulk of the OFI implementation resides in the providers.  Providers plug into the framework and supply access to fabric hardware and services.  Providers are often associated with a specific hardware device or NIC.  Because of the structure of the OFI framework, applications access the provider implementation directly for most operations, in order to ensure the lowest possible software latencies.
+
+# Control services
+## Communication services
+## Completion services
+## Data transfer services
+## Memory registration
+# Object Model
+# Communication Model
+## Connected communications
+## Connectionless communications
+# Data Transfers
+## Endpoints
 		Shared Contexts
 			Rx
 			Tx
 		Scalable Endpoints
-	Message transfers
-	Tagged messages
-	RMA
-	Atomic operations
-Fabric Interfaces
-	fi_info / fi_getinfo
-		Capabilities
-		Mode bits
-		Addressing
-	Fabric
-		Attributes
-		Accessing
-	Domains
+## Message transfers
+## Tagged messages
+## RMA
+## Atomic operations
+# Fabric Interfaces
+## fi_info / fi_getinfo
+### Capabilities
+### Mode bits
+### Addressing
+## Fabric
+### Attributes
+### Accessing
+## Domains
 		Attributes
 		Opening
 		Memory registration
-	Endpoints
+## Endpoints
 		Active
 			Enabling
 		Passive
@@ -82,7 +97,7 @@ Fabric Interfaces
 		EP Attributes
 		Rx Attributes
 		Tx Attributes
-	Completions
+## Completions
 		CQs
 			Attributes
 			Reading completions
@@ -90,16 +105,16 @@ Fabric Interfaces
 		Counters
 			Checking value
 			Error reporting
-	Address Vectors
+## Address Vectors
 		Types
 		Address formats
 		Insertion methods
 		Sharing with other processes
-	Wait and Poll Sets
-		Blocking on events
-			TryWait
-			Wait
-		Efficiently checking multiple queues
-Putting It All Together
-	MSG EP pingpong
-	RDM EP pingpong
+## Wait and Poll Sets
+### Blocking on events
+#### TryWait
+#### Wait
+### Efficiently checking multiple queues
+# Putting It All Together
+## MSG EP pingpong
+## RDM EP pingpong

--- a/OFIGuide.md
+++ b/OFIGuide.md
@@ -17,6 +17,9 @@ The goal of OFI, and libfabric specifically, is to define interfaces that enable
 This guide describes the libfabric architecture and interfaces.  It provides insight into the motivation for its design, and aims to instruct developers on how the features of libfabric may best be employed.
 
 # Review of Sockets Communication
+
+The sockets API is a widely used networking API.  This guide assumes that a reader has a working knowledge of programming to sockets.  It makes reference to socket based communications throughout, in an effort to help explain libfabric concepts and how they relate or differ from the socket API.
+
 ## Connected (TCP) Communication
 ## Connectionless (UDP) Communication
 ## Advantages

--- a/OFIGuide.md
+++ b/OFIGuide.md
@@ -8,10 +8,11 @@ tagline: Libfabric Programmer's Guide
 
 # Introduction
 # Review of Sockets Communication
-## Connected (TCP) communication
-## Connectionless (UDP) communication
+## Connected (TCP) Communication
+## Connectionless (UDP) Communication
 ## Advantages
 ## Disadvantages
+
 # High-Performance Networking
 ## Avoiding memory copies
 ### Network buffers
@@ -22,6 +23,7 @@ tagline: Libfabric Programmer's Guide
 ## Direct hardware access
 ### Kernel bypass
 ### Direct data placement
+
 # Designing Interfaces for Performance
 ## Call setup costs
 ## Branches and loops
@@ -41,6 +43,7 @@ tagline: Libfabric Programmer's Guide
 ### Message
 ### Completion
 ### Data
+
 # OFI Architecture
 # Framework versus Provider
 # Control services

--- a/OFIGuide.md
+++ b/OFIGuide.md
@@ -6,18 +6,7 @@ tagline: Libfabric Programmer's Guide
 {% include JB/setup %}
 
 
-
 # Introduction
-
-
-OpenFabrics Interfaces, or OFI, is a framework focused on exporting fabric communication services to applications.  OFI is specifically designed to meet the performance and scalability requirements of high-performance computing (HPC) applications, such as MPI, SHMEM, PGAS, DBMS, and enterprise applications, running in a tightly coupled network environment.  The key components are OFI are: application interfaces, provider libraries, kernel services, daemons, and test applications.
-
-Libfabric is a core component of OFI.  It is the library that defines and exports the user-space API of OFI, and is typically the only software that applications deal with directly.  Libfabric is supported on commonly available Linux based distributions.  Libfabric is agnostic to the underlying networking protocols, as well as the implementation of the networking devices.
-
-Libfabric is architected to support process direct I/O.  Process direct I/O, historically referred to as RDMA, allows an application to access network resources without operating system interventions.  Data transfers can occur between networking hardware and application memory with minimal software overhead.  Although libfabric supports process direct I/O, it does not mandate any implementation or require operating system bypass.
-
-
-
 # Review of Sockets Communication
 ## Connected (TCP) communication
 ## Connectionless (UDP) communication
@@ -28,35 +17,32 @@ Libfabric is architected to support process direct I/O.  Process direct I/O, his
 ### Network buffers
 ### Resource management
 ## Asynchronous operations
-		Interrupts and signals
-		Event queues
+### Interrupts and signals
+### Event queues
 ## Direct hardware access
-		Kernel bypass
-		Direct data placement
+### Kernel bypass
+### Direct data placement
 # Designing Interfaces for Performance
 ## Call setup costs
 ## Branches and loops
 ## Command formatting
 ##  Memory footprint
-		Addressing
-		Communication resources
-		Network Buffering
-			Shared Rx queues
-			Multi-receive buffers
+### Addressing
+### Communication resources
+### Network Buffering
+#### Shared Rx queues
+#### Multi-receive buffers
 ## Optimal hardware allocation
-		Shared queues
-		Multiple queues
+### Shared queues
+### Multiple queues
 ## Progress model considerations
 ## Multi-threading synchronization
 ## Ordering
-		Message
-		Completion
-		Data
+### Message
+### Completion
+### Data
 # OFI Architecture
-
 # Framework versus Provider
-OFI is divided into two separate components.  The main component is the OFI framework, which defines the interfaces that applications use.  The OFI frameworks provides some generic services; however, the bulk of the OFI implementation resides in the providers.  Providers plug into the framework and supply access to fabric hardware and services.  Providers are often associated with a specific hardware device or NIC.  Because of the structure of the OFI framework, applications access the provider implementation directly for most operations, in order to ensure the lowest possible software latencies.
-
 # Control services
 ## Communication services
 ## Completion services
@@ -68,10 +54,10 @@ OFI is divided into two separate components.  The main component is the OFI fram
 ## Connectionless communications
 # Data Transfers
 ## Endpoints
-		Shared Contexts
-			Rx
-			Tx
-		Scalable Endpoints
+### Shared Contexts
+#### Rx
+#### Tx
+### Scalable Endpoints
 ## Message transfers
 ## Tagged messages
 ## RMA
@@ -85,31 +71,31 @@ OFI is divided into two separate components.  The main component is the OFI fram
 ### Attributes
 ### Accessing
 ## Domains
-		Attributes
-		Opening
-		Memory registration
+### Attributes
+### Opening
+### Memory registration
 ## Endpoints
-		Active
-			Enabling
-		Passive
-		Scalable
-		Resource Bindings
-		EP Attributes
-		Rx Attributes
-		Tx Attributes
+### Active
+#### Enabling
+### Passive
+### Scalable
+### Resource Bindings
+### EP Attributes
+### Rx Attributes
+### Tx Attributes
 ## Completions
-		CQs
-			Attributes
-			Reading completions
-			Retrieving errors
-		Counters
-			Checking value
-			Error reporting
+### CQs
+#### Attributes
+#### Reading completions
+#### Retrieving errors
+### Counters
+#### Checking value
+#### Error reporting
 ## Address Vectors
-		Types
-		Address formats
-		Insertion methods
-		Sharing with other processes
+### Types
+### Address formats
+### Insertion methods
+### Sharing with other processes
 ## Wait and Poll Sets
 ### Blocking on events
 #### TryWait


### PR DESCRIPTION
Provide a rough outline for the material.  The intent is to
pull content from other documents and the man pages, but add
considerable details regarding why the API is defined the way
that it is.  It will assume that the reader is familiar with
sockets programming, and make references to sockets where
possible in order to aid understanding of the API.

The book will be written using markdown and maintained as
part of the repository.  It can be published as html on
github and also published from gitbooks.

Signed-off-by: Sean Hefty sean.hefty@intel.com
